### PR TITLE
Boost never slows down, and shake scales more aggressively.

### DIFF
--- a/Assets/Scripts/CameraController.cs
+++ b/Assets/Scripts/CameraController.cs
@@ -6,16 +6,18 @@ public class CameraController : MonoBehaviour {
     public static float zoomFactor = 1.0f;
 
     public GameObject player;
-    public float updateSpeed = 0.15f;
-    public float shakeVelocityThreshold = 10.0f;
-    public float maxShakeDuration = 0.2f;
+    public float updateSpeed = 0.1f;
+    public float lowerSpeedDeltaThreshold = 10.0f;
+    public float upperSpeedDeltaThreshold = 20.0f;
+    public float maxShakeDuration = 0.3f;
     public float maxTranslateAmountStart = 0.2f;
     public float maxRotateAmountStart = 4.0f;
-    public float shakeLeftTime = 0.0f;
+    public float minShakePercent = 0.25f;
 
     private Vector3 offset;
     private Quaternion initialRotation;
     private Vector3 previousVelocity;
+    private float shakeLeftTime = 0.0f;
 
     void Start() {
         this.offset = transform.position - player.transform.position;
@@ -23,12 +25,13 @@ public class CameraController : MonoBehaviour {
         this.initialRotation = transform.rotation;
     }
 
-    void Update() {
+    void LateUpdate() {
         Vector3 targetPosition = player.transform.position + (offset * zoomFactor);
         transform.position = Vector3.Lerp(transform.position, targetPosition, updateSpeed);
         transform.rotation = Quaternion.Lerp(transform.rotation, initialRotation, updateSpeed);
         if (shakeLeftTime > 0)
         {
+            // The goal here is to have the initial shaking be the biggest, and then decay to zero as it stops.
             float shakePercent = Mathf.Lerp(0, 1, shakeLeftTime / maxShakeDuration);
             transform.position += shakePercent * maxTranslateAmountStart * Random.insideUnitSphere ;
             transform.rotation *= Quaternion.Euler(0, 0, Random.value * shakePercent * maxRotateAmountStart);
@@ -40,10 +43,12 @@ public class CameraController : MonoBehaviour {
         Vector3 currentVelocity = player.GetComponent<Rigidbody>().velocity;
         float maxDelta = currentVelocity.magnitude + previousVelocity.magnitude;
         float actualDelta = Vector3.Distance(currentVelocity, previousVelocity);
-        // The comparison between actualDelta and maxDelta is making sure that the direction of the velocity changed significantly.
-        // The comparison between actualDelta and shakeVelocityThreshold is making sure the player was traveling quickly.
-        if (actualDelta > (maxDelta / 2) && actualDelta >= shakeVelocityThreshold) {
-            float shakePercentToApply = (actualDelta / maxDelta) * Mathf.Lerp(0, 1, actualDelta / shakeVelocityThreshold);
+
+        float directionPercent = Mathf.InverseLerp(0, maxDelta, actualDelta);
+        float speedPercent = Mathf.InverseLerp(lowerSpeedDeltaThreshold, upperSpeedDeltaThreshold, actualDelta);
+        float shakePercentToApply = Mathf.Min(directionPercent, speedPercent);
+
+        if (shakePercentToApply > minShakePercent) {
             shakeLeftTime = shakePercentToApply * maxShakeDuration;
         }
         previousVelocity = currentVelocity;

--- a/Assets/Scripts/General.cs
+++ b/Assets/Scripts/General.cs
@@ -27,7 +27,6 @@ public sealed class General : MonoBehaviour {
     private float startTime = 3.0f;
     private float timer = 0.0f;
 
-
     private void Awake() {
         if (instance != null && instance != this) {
             print("Destroying game object: " + this.gameObject);

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -30,6 +30,7 @@ public class PlayerController : MonoBehaviour {
     private bool hasBoosted = false;
     private float boostCooldownMaxtime = 2.0f;
     private float boostCooldownTimer = 0.0f;
+    private float boostForce = 400.0f;
 
     // Stuff for ball texture
     private bool scaleSwitch;
@@ -66,10 +67,12 @@ public class PlayerController : MonoBehaviour {
         // Boost powerup used
         if ((Input.GetKeyDown(KeyCode.LeftShift) || Input.GetKeyDown(KeyCode.RightShift)) && this.gotBoostPowerup && this.hasBoosted == false && IsGrounded()) {
             this.hasBoosted = true;
-            Vector3 nVelocity = playerLastMovement.normalized;
-            this.rb.velocity = Vector3.zero;
-            Vector3 boostSpeed = nVelocity * 400;
-            this.rb.AddForce(boostSpeed);
+            Vector3 normalizedMovement = playerLastMovement.normalized;
+
+            // Strip away all velocity not in the direction of desired movement.
+            rb.velocity = normalizedMovement * Mathf.Max(Vector3.Dot(normalizedMovement, rb.velocity), 0);
+
+            this.rb.AddForce(normalizedMovement * boostForce);
             this.boostCooldownTimer = this.boostCooldownMaxtime;
             this.RenderBallAfterPowerup();
         }
@@ -79,15 +82,13 @@ public class PlayerController : MonoBehaviour {
             playerLastPosition = this.transform.position;
 
             // For Debugging collisions (sp?)
-            /* foreach(var ray in Physics.RaycastAll(this.transform.position, Vector3.down, 0.6f)){
+            /* foreach(var ray in Physics.RaycastAll(this.transform.position, Vector3.down, 0.6f)) {
              *  print(ray.transform.name);
             } */ 
         }
     }
 
     void Update() {
-        
-
         // Return player if they are out of bounds TODO: Do this better
         if (this.transform.position.y <= playerLastPosition.y - 10.0f) {
             rb.velocity = Vector3.zero;


### PR DESCRIPTION
Previously if you were traveling as fast as you could and boosted it would slow you down. In this patch we strip off all existing velocity that's not in the direction of the boost, meaning that a boost will always send you towards where you want to go faster than you used to be.

The calculations for shake's percent to apply were sloppy and rough. Using reverse lerp essentially had them calculate the percent between two thresholds, and use the min of angle change and speed change. The result is that most screen shakes are far from max now.