### PR TITLE
Stopped using OnDestroy as this is triggered on scene end.

### DIFF
--- a/Assets/Scripts/PickUp.cs
+++ b/Assets/Scripts/PickUp.cs
@@ -9,7 +9,8 @@ public class PickUp : MonoBehaviour {
         platform.RegisterPickUp(this);
     }
 
-    void OnDestroy() {
+    public void Collect() {
         platform.CollectPickUp(this);
+        Destroy(this.gameObject);
     }
 }

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -171,7 +171,7 @@ public class PlayerController : MonoBehaviour {
 
     void OnTriggerEnter(Collider other) {
         if (other.gameObject.CompareTag("Pick Up")) {
-            Destroy(other.gameObject);
+            other.gameObject.GetComponent<PickUp>().Collect();
         }
         if (other.gameObject.CompareTag("JumpPowerup")) {
             this.gotJumpPowerup = true;


### PR DESCRIPTION
The destruction order of General and the PickUp objects is non-deterministic, and if General is destroyed before any of them (it usually is), we NRE.